### PR TITLE
Fixed wrong firebase variable name

### DIFF
--- a/generators/app/templates/app/utils/firebase.js
+++ b/generators/app/templates/app/utils/firebase.js
@@ -1,8 +1,8 @@
 import { firebase as config } from '../config'
-const { apiKey, authDomain, databaseUrl, storageBucket } = config
+const { apiKey, authDomain, databaseURL, storageBucket } = config
 import Firebase from 'firebase'
 
 // Initialize Firebase
-Firebase.initializeApp({ apiKey, authDomain, databaseUrl, storageBucket })
+Firebase.initializeApp({ apiKey, authDomain, databaseURL, storageBucket })
 
 export default Firebase


### PR DESCRIPTION
Small issue with the name of variable used by firebase.

```
firebase.js?678b:281Uncaught Error: FIREBASE FATAL ERROR: Can't determine Firebase Database URL.  Be sure to include databaseURL option when calling firebase.intializeApp().
```