### PR TITLE
Wrong import call name in index-server.js file

### DIFF
--- a/generators/app/templates/lib/index-server.js
+++ b/generators/app/templates/lib/index-server.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import React from 'react' //eslint-disable-line
-import createRoutes from '../app/router'
+import createRoutes from '../app/routes'
 import { match, RouterContext } from 'react-router'
 import { renderToString } from 'react-dom/server'
 import { Provider } from 'react-redux'


### PR DESCRIPTION
When try build a small mistake appears.

```
 70% 2/2 build modulesModuleNotFoundError: Module not found: Error: Cannot resolve 'file' or 'directory' ../app/router in /Users/Bruno/Workspace/scaffolds/react-firebase/myProject/l

...
```