### PR TITLE
Fix for deployed `index.html` pointing to localhost js files (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A Travis-CI file has been included to enable CI builds. The correct configuratio
   * What do you want to use as your public directory? -> `dist`
   * Configure as a single-page app (rewrite all urls to /index.html)? -> `Yes`
   * What Firebase project do you want to associate as default?  -> **your Firebase project name**
-5. Build Project: `npm run build`
+5. Build Project: `npm run build:prod`
 6. Confirm Firebase config by running locally: `firebase serve`
 7. Deploy to firebase: `firebase deploy`
 


### PR DESCRIPTION
Got caught by this when deploying. :)
