### PR TITLE
v1.4.1

### DIFF
--- a/examples/react-firebase-redux/.travis.yml
+++ b/examples/react-firebase-redux/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 language: node_js
 
 node_js:
- - 6.11.0
+ - 6.11.1 # runtime used within Firebase functions
 
 notifications:
   email:
@@ -26,7 +26,6 @@ cache:
 install:
   - npm set progress=false
   - npm i
-  -
   - npm i -g firebase-ci
   - firebase-ci createConfig
 
@@ -40,4 +39,4 @@ addons:
     repo_token: $CODE_CLIMATE
 
 after_success:
-  - firebase-ci deploy
+  - firebase-ci deploy -s # deploy without CI actions since createConfig is called earlier 

--- a/examples/react-firebase-redux/package.json
+++ b/examples/react-firebase-redux/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^15.5.4",
     "react-google-button": "^0.3.0",
     "react-redux": "^5.0.4",
-    "react-redux-firebase": "^1.5.0-rc.1",
+    "react-redux-firebase": "^1.5.0-rc.2",
     "react-router": "^3.0.0",
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.6.0",

--- a/examples/react-firebase-redux/src/routes/NotFound/NotFound.js
+++ b/examples/react-firebase-redux/src/routes/NotFound/NotFound.js
@@ -6,3 +6,5 @@ export const NotFound = () => (
     <p>This page was not found.</p>
   </div>
 )
+
+export default NotFound

--- a/examples/react-firebase-redux/yarn.lock
+++ b/examples/react-firebase-redux/yarn.lock
@@ -5059,10 +5059,6 @@ react-addons-test-utils@^15.5.1:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
 
-react-display-name@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.0.tgz#0e1f7086e45a32d07764df35ed32ff16f1259790"
-
 react-dom@^15.5.4:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
@@ -5098,9 +5094,9 @@ react-google-button@^0.3.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-redux-firebase@^1.5.0-rc.1:
-  version "1.5.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-redux-firebase/-/react-redux-firebase-1.5.0-rc.1.tgz#c820141afe179f21a1388a44b28e64cb6edd774e"
+react-redux-firebase@^1.5.0-rc.2:
+  version "1.5.0-rc.2"
+  resolved "https://registry.yarnpkg.com/react-redux-firebase/-/react-redux-firebase-1.5.0-rc.2.tgz#5af4b4b7f397899d9e19d721dc857d1eb1f6dd1f"
   dependencies:
     es6-promise "^4.1.0"
     firebase "^3.9.0"
@@ -5109,7 +5105,6 @@ react-redux-firebase@^1.5.0-rc.1:
     jwt-decode "^2.2.0"
     lodash "^4.17.4"
     prop-types "^15.5.8"
-    react-display-name "^0.2.0"
 
 react-redux@^5.0.4:
   version "5.0.5"

--- a/generators/app/templates/_travis.yml
+++ b/generators/app/templates/_travis.yml
@@ -5,7 +5,7 @@ sudo: false
 language: node_js
 
 node_js:
- - 6.11.0
+ - 6.11.1 <% if (deployTo === 'firebase') { %># runtime used within Firebase functions<% } %>
 
 notifications:
   email:
@@ -22,12 +22,11 @@ cache:
   bundler: true
   directories:
     - node_modules # NPM packages
-
+<% if (deployTo === 'firebase') { %>
 install:
   - npm set progress=false
   - npm i
-  -
-  <% if (deployTo === 'firebase') { %>- npm i -g firebase-ci
+  - npm i -g firebase-ci
   - firebase-ci createConfig<% } %>
 
 script:
@@ -40,7 +39,7 @@ addons:
     repo_token: $CODE_CLIMATE<% } %>
 
 <% if (deployTo === 'firebase') { %>after_success:
-  - firebase-ci deploy<% } %><% if (deployTo === 'heroku') { %>deploy:
+  - firebase-ci deploy -s # deploy without CI actions since createConfig is called earlier <% } %><% if (deployTo === 'heroku') { %>deploy:
   skip_cleanup: true
   provider: heroku
   api_key:

--- a/generators/app/templates/src/routes/NotFound/NotFound.js
+++ b/generators/app/templates/src/routes/NotFound/NotFound.js
@@ -6,3 +6,5 @@ export const NotFound = () => (
     <p>This page was not found.</p>
   </div>
 )
+
+export default NotFound

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-react-firebase",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Starter that uses React and Firebase (with option for Redux)",
   "main": "generators/index.js",
   "scripts": {


### PR DESCRIPTION
* Default export added to `NotFound` component - #56
* Extra line removed from `.travis.yml` template
* Now using `-s` option with `firebase-ci deploy` (only runs deploy, not other deploy actions such as [`mapEnv`](https://github.com/prescottprue/firebase-ci#mapenv) and [`copyVersion`](https://github.com/prescottprue/firebase-ci#copyversion))