### PR TITLE
removed duplicate env export that crashes app on start

### DIFF
--- a/generators/app/templates/src/config.js
+++ b/generators/app/templates/src/config.js
@@ -24,6 +24,4 @@ export const reduxFirebase = {
   // profileDecorator: (userData) => ({ email: userData.email }) // customize format of user profile
 }
 
-export const env = 'development'
-
 export default { env, firebase, reduxFirebase }


### PR DESCRIPTION
### Description
Upon installing with 'yo react firebase' and running with 'yarn start' the app crashes with the error:

```
`env` has already been exported. Exported identifiers must be unique. (.../APPNAME/src/config.js:27:14)
  25 | }
  26 | 
> 27 | export const env = 'development'
     |              ^
  28 | 
  29 | export default { env, firebase, reduxFirebase }
  30 | 

```
 Easy mistake - easy catch! My first open source contribution - I think I'll buy myself a beer.

GREAT Generator by the way. Very well maintained and documented. Thanks for your work.


### Check List

- [ X] All test passed 
- [ ] Updated Any Relevant Docs
