### PR TITLE
Router matches <%= name %> instead <%= name %>page

### DIFF
--- a/generators/route/templates/_index.js
+++ b/generators/route/templates/_index.js
@@ -11,7 +11,7 @@ export default store => ({
       require => {
         /*  Webpack - use require callback to define
           dependencies for bundling   */
-        const <%= name %> = require('./components/<%= name %>Page').default
+        const <%= name %> = require('./components/<%= name %>').default
 
         /*  Return getComponent   */
         cb(null, <%= name %>)


### PR DESCRIPTION
### Description
In case of Router generator component looks for <%= name %> instead <%= name %>page


### Check List

- [ ] All test passed
- [ ] Updated Any Relevant Docs
