### PR TITLE
Fixes firebaseConnect import on generating component

### DIFF
--- a/generators/component/templates/_main.enhancer.js
+++ b/generators/component/templates/_main.enhancer.js
@@ -1,6 +1,6 @@
 import { compose } from 'redux'
 import { connect } from 'react-redux'
-import { <% if (usingFirestore) { %>firestoreConnect<% } %><% if (!usingFirestore) { %>firestoreConnect<% } %> } from 'react-redux-firebase'
+import { <% if (usingFirestore) { %>firestoreConnect<% } %><% if (!usingFirestore) { %>firebaseConnect<% } %> } from 'react-redux-firebase'
 
 export default compose(
   // create listener for <%= lowerName %>, results go into redux


### PR DESCRIPTION
During yo generate component and when we are not using firestoreConnect, firebaseConnect should be imported. As of now, firebaseConnect is not imported causing an error. This change will fix it.

### Description


### Check List

- [ ] All test passed
- [ ] Updated Any Relevant Docs
