### PR TITLE
Switch react-redux-firebase imports to lib

### DIFF
--- a/generators/app/templates/src/containers/Navbar/Navbar.enhancer.js
+++ b/generators/app/templates/src/containers/Navbar/Navbar.enhancer.js
@@ -9,7 +9,8 @@ import {
 } from 'recompose'
 import { withStyles } from '@material-ui/core/styles'
 import { withRouter } from 'react-router-dom'
-import { withFirebase, isEmpty, isLoaded } from 'react-redux-firebase'
+import withFirebase from 'react-redux-firebase/lib/withFirebase'
+import { isEmpty, isLoaded } from 'react-redux-firebase/lib/helpers'
 import { ACCOUNT_PATH } from 'constants/paths'
 import styles from './Navbar.styles'
 

--- a/generators/app/templates/src/routes/Account/components/AccountPage/AccountPage.enhancer.js
+++ b/generators/app/templates/src/routes/Account/components/AccountPage/AccountPage.enhancer.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 <% if (includeRedux) { %>import { connect } from 'react-redux'
-import { withFirebase } from 'react-redux-firebase'
+import withFirebase from 'react-redux-firebase/lib/withFirebase'
 import { withHandlers, compose, setPropTypes } from 'recompose'
 import { spinnerWhileLoading } from 'utils/components'
 import { withNotifications } from 'modules/notification'

--- a/generators/app/templates/src/routes/Login/components/LoginPage/LoginPage.enhancer.js
+++ b/generators/app/templates/src/routes/Login/components/LoginPage/LoginPage.enhancer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { withFirebase } from 'react-redux-firebase'
+import withFirebase from 'react-redux-firebase/lib/withFirebase'
 import { withHandlers, compose, setPropTypes, setDisplayName } from 'recompose'
 import { withStyles } from '@material-ui/core/styles'
 import { UserIsNotAuthenticated } from 'utils/router'

--- a/generators/app/templates/src/routes/Projects/components/ProjectsPage/ProjectsPage.enhancer.js
+++ b/generators/app/templates/src/routes/Projects/components/ProjectsPage/ProjectsPage.enhancer.js
@@ -1,13 +1,14 @@
 import { compose } from 'redux'
 import { connect } from 'react-redux'
-import { LIST_PATH } from 'constants/paths'
 import { withHandlers, withStateHandlers, setDisplayName } from 'recompose'
-import { withRouter } from 'react-router-dom'
-import { <% if (includeRedux && includeFirestore) { %>firestoreConnect<% } %><% if (includeRedux && !includeFirestore) { %>firebaseConnect<% } %> } from 'react-redux-firebase'
+import { withRouter } from 'react-router-dom'<% if (includeRedux && includeFirestore) { %>
+import firestoreConnect from 'react-redux-firebase/lib/firestoreConnect'<% } %><% if (includeRedux && !includeFirestore) { %>
+import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect'<% } %>
 import { withStyles } from '@material-ui/core/styles'
 import { withNotifications } from 'modules/notification'
 import { spinnerWhileLoading } from 'utils/components'
 import { UserIsAuthenticated } from 'utils/router'
+import { LIST_PATH } from 'constants/paths'
 import styles from './ProjectsPage.styles'
 
 export default compose(

--- a/generators/app/templates/src/routes/Projects/components/ProjectsPage/ProjectsPage.js
+++ b/generators/app/templates/src/routes/Projects/components/ProjectsPage/ProjectsPage.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { isEmpty } from 'react-redux-firebase'
+import { isEmpty } from 'react-redux-firebase/lib/helpers'
 import { Route, Switch } from 'react-router-dom'
 import ProjectRoute from 'routes/Projects/routes/Project'
 import ProjectTile from '../ProjectTile'

--- a/generators/app/templates/src/routes/Projects/routes/Project/components/ProjectPage/ProjectPage.enhancer.js
+++ b/generators/app/templates/src/routes/Projects/routes/Project/components/ProjectPage/ProjectPage.enhancer.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
 import { compose } from 'redux'
 import { connect } from 'react-redux'
-import { get } from 'lodash'
-<% if (includeRedux && includeFirestore) { %>import { firestoreConnect } from 'react-redux-firebase'<% } %><% if (includeRedux && !includeFirestore) { %>import { firebaseConnect } from 'react-redux-firebase'<% } %>
+import { get } from 'lodash'<% if (includeRedux && includeFirestore) { %>
+import firestoreConnect from 'react-redux-firebase/lib/firestoreConnect'<% } %><% if (includeRedux && !includeFirestore) { %>
+import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect'<% } %>
 import { withStyles } from '@material-ui/core/styles'
 import { withRouter } from 'react-router-dom'
 import { setPropTypes, setDisplayName, withProps } from 'recompose'

--- a/generators/app/templates/src/routes/Signup/components/SignupPage/SignupPage.enhancer.js
+++ b/generators/app/templates/src/routes/Signup/components/SignupPage/SignupPage.enhancer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { withFirebase } from 'react-redux-firebase'
+import withFirebase from 'react-redux-firebase/lib/withFirebase'
 import { withHandlers, compose, setPropTypes, setDisplayName } from 'recompose'
 import { withStyles } from '@material-ui/core/styles'
 import { UserIsNotAuthenticated } from 'utils/router'

--- a/generators/app/templates/src/store/createStore.js
+++ b/generators/app/templates/src/store/createStore.js
@@ -1,7 +1,8 @@
 import { applyMiddleware, compose, createStore } from 'redux'
 import thunk from 'redux-thunk'
-import { reactReduxFirebase, getFirebase } from 'react-redux-firebase'<% if (includeRedux && includeFirestore) { %>
-import { reduxFirestore } from 'redux-firestore'<% } %>
+import reactReduxFirebase from 'react-redux-firebase/lib/enhancer'
+import { getFirebase } from 'react-redux-firebase/lib/createFirebaseInstance'<% if (includeRedux && includeFirestore) { %>
+import reduxFirestore from 'redux-firestore/lib/enhancer'<% } %>
 import firebase from 'firebase/app'
 import 'firebase/database'
 import 'firebase/auth'

--- a/generators/app/templates/src/store/reducers.js
+++ b/generators/app/templates/src/store/reducers.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux'
-import { firebaseReducer as firebase } from 'react-redux-firebase'<% if (includeRedux && includeFirestore) { %>
-import { reducer as firestore } from 'redux-firestore'<% } %>
+import firebase from 'react-redux-firebase/lib/reducers'<% if (includeRedux && includeFirestore) { %>
+import firestore from 'redux-firestore/lib/reducers'<% } %>
 import { reducer as form } from 'redux-form'
 import { reducer as notifications } from 'modules/notification'
 import locationReducer from './location'

--- a/generators/app/templates/src/utils/components.js
+++ b/generators/app/templates/src/utils/components.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { pick, some } from 'lodash'
-import { isLoaded } from 'react-redux-firebase'
+import { isLoaded } from 'react-redux-firebase/lib/helpers'
 import LoadableComponent from 'react-loadable'
 import { mapProps, branch, renderComponent } from 'recompose'
 import LoadingSpinner from 'components/LoadingSpinner'
@@ -25,7 +25,7 @@ export const spinnerWhile = condition =>
  * @example Spinner While Data Loading
  * import { compose } from 'redux'
  * import { connect } from 'react-redux'
- * import { firebaseConnect } from 'react-redux-firebase'
+ * import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect'
  *
  * const enhance = compose(
  *   firebaseConnect(['projects']),
@@ -47,7 +47,7 @@ export const spinnerWhileLoading = propNames =>
  * @example Log Single Prop
  * import { compose } from 'redux'
  * import { connect } from 'react-redux'
- * import { firebaseConnect } from 'react-redux-firebase'
+ * import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect'
  *
  * const enhance = compose(
  *   withProps(() => ({ projectName: 'test' })),

--- a/generators/enhancer/templates/_main-airbnb.enhancer.js
+++ b/generators/enhancer/templates/_main-airbnb.enhancer.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux';
-import { connect } from 'react-redux';
-import { <% if (usingFirestore) { %>firestoreConnect<% } %><% if (!usingFirestore) { %>firebaseConnect<% } %> } from 'react-redux-firebase';
+import { connect } from 'react-redux';<% if (usingFirestore) { %>
+import firestoreConnect from 'react-redux-firebase/lib/firestoreConnect';<% } else { %>
+import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect';<% } %>
 
 export default compose(
   // create listener for <%= camelName %>, results go into redux state

--- a/generators/enhancer/templates/_main.enhancer.js
+++ b/generators/enhancer/templates/_main.enhancer.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux'
-import { connect } from 'react-redux'
-import { <% if (usingFirestore) { %>firestoreConnect<% } %><% if (!usingFirestore) { %>firebaseConnect<% } %> } from 'react-redux-firebase'
+import { connect } from 'react-redux'<% if (usingFirestore) { %>
+import firestoreConnect from 'react-redux-firebase/lib/firestoreConnect'<% } else { %>
+import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect'<% } %>
 
 export default compose(
   // create listener for <%= camelName %>, results go into redux

--- a/generators/route/templates/component/_main-airbnb.enhancer.js
+++ b/generators/route/templates/component/_main-airbnb.enhancer.js
@@ -1,12 +1,13 @@
 import { compose } from 'redux';
-import { connect } from 'react-redux';
-import { <% if (usingFirestore) { %>firestoreConnect<% } %><% if (!usingFirestore) { %>firebaseConnect<% } %> } from 'react-redux-firebase';<% if (styleType === 'localized') { %>
+import { connect } from 'react-redux';<% if (usingFirestore) { %>
+import firestoreConnect from 'react-redux-firebase/lib/firestoreConnect';<% } else { %>
+import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect';<% } %><% if (styleType === 'localized') { %>
 import { withStyles } from '@material-ui/core/styles';
 import styles from './<%= componentName %>.styles';<% } %>
 
 export default compose(
   // create listener for <%= camelName %>, results go into redux
-  <% if (!usingFirestore) { %>firebaseConnect([{ path: '<%= camelName %>' }]), <% } %><% if (usingFirestore) { %> firestoreConnect([{ collection: '<%= camelName %>' }]),<% } %>
+  <% if (!usingFirestore) { %>firebaseConnect([{ path: '<%= camelName %>' }]), <% } %><% if (usingFirestore) { %>firestoreConnect([{ collection: '<%= camelName %>' }]),<% } %>
   // map redux state to props
   connect(({ <% if (usingFirestore) { %> firestore <% } else { %> firebase <% } %>: { data } }) => ({
     <%= camelName %>: data.<%= camelName %>

--- a/generators/route/templates/component/_main.enhancer.js
+++ b/generators/route/templates/component/_main.enhancer.js
@@ -1,6 +1,7 @@
 import { compose } from 'redux'
-import { connect } from 'react-redux'
-import { <% if (usingFirestore) { %>firestoreConnect<% } %><% if (!usingFirestore) { %>firebaseConnect<% } %> } from 'react-redux-firebase'<% if (styleType === 'localized') { %>
+import { connect } from 'react-redux'<% if (usingFirestore) { %>
+import firestoreConnect from 'react-redux-firebase/lib/firestoreConnect'<% } else { %>
+import firebaseConnect from 'react-redux-firebase/lib/firebaseConnect'<% } %><% if (styleType === 'localized') { %>
 import { withStyles } from '@material-ui/core/styles'
 import styles from './<%= componentName %>.styles'<% } %>
 


### PR DESCRIPTION
### Description
* Switch react-redux-firebase/redux-firestore imports to use `/lib` instead of top level imports to save on bundle size

### Check List

- [X] All test passed
- [X] Updated Any Relevant Docs
