### PR TITLE
v6.1.0

### DIFF
--- a/examples/react-firebase/.babelrc
+++ b/examples/react-firebase/.babelrc
@@ -1,8 +1,0 @@
-/**
- * WARNING: This file is just to prevent from global .babelrc files!
- * This babel funcitonality is actually controlled within config/index.js
- **/
-{
-  "plugins": ["transform-runtime", "lodash", "transform-decorators-legacy"],
-  "presets": ["es2015", "react", "stage-0"]
-}

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -270,36 +270,19 @@ module.exports = class extends Generator {
       )
     )
 
-    function runPrompts(githubUsername) {
-      // Set github username as default
-      const [firstPrompt, ...restOfPrompts] = prompts
-      const modifiedPrompts = [
-        { ...firstPrompt, default: githubUsername || '' },
-        ...restOfPrompts
-      ]
-      return this.prompt(modifiedPrompts).then((props) => {
-        this.answers = props
-        // Map features array to answerNames
-        if (props.otherFeatures) {
-          featureChoices.forEach((choice) => {
-            const matching = props.otherFeatures.find(
-              (feature) => choice.name === feature
-            )
-            this.answers[choice.answerName] = !!matching
-          })
-        }
-        this.data = Object.assign({}, this.initialData, this.answers)
-      })
-    }
-    const boundRunPrompts = runPrompts.bind(this)
-
-    // Run prompts regardless of if getting github username is successful
-    return this.user.github
-      .username()
-      .then(boundRunPrompts)
-      .catch(() => {
-        boundRunPrompts()
-      })
+    return this.prompt(prompts).then((props) => {
+      this.answers = props
+      // Map features array to answerNames
+      if (props.otherFeatures) {
+        featureChoices.forEach((choice) => {
+          const matching = props.otherFeatures.find(
+            (feature) => choice.name === feature
+          )
+          this.answers[choice.answerName] = !!matching
+        })
+      }
+      this.data = Object.assign({}, this.initialData, this.answers)
+    })
   }
 
   writing() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-react-firebase",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "React and Firebase (with option for Redux) starter project generator.",
   "main": "generators/index.js",
   "scripts": {


### PR DESCRIPTION

### Description
* fix(core): revert defaulting with github username due to context issues - #226

More Context
* [This change was made](https://github.com/prescottprue/generator-react-firebase/commit/add35ed824b9ec4f84a5d1cff911e177e065c45b#diff-def8dd7c5bf7421ace8ec454d89f771cR273-R302) to default the github username field in the prompts to the user's username loaded through an internal Yeoman API

### Screenshots (if appropriate)
