### PR TITLE
fix(app): use correct github deploy workflow env variable setting syntax

### DIFF
--- a/examples/react-firebase-redux/.github/workflows/deploy.yml
+++ b/examples/react-firebase-redux/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
               sed 's/.*initializeApp(//g' | \
               sed 's/);//g' | \
               jq -r 'to_entries[] | [.key, (.value | tojson)] | join("::")' | \
-              sed 's/:"/:/g; s/^/echo \"::set-env name=REACT_APP_FIREBASE_/g' \
+              sed 's/::"/=/g; s/^/echo \"::set-env name=REACT_APP_FIREBASE_/g' \
           )
 
           # Loop through each line of config and evaluate to export env vars

--- a/examples/react-firebase/.github/workflows/deploy.yml
+++ b/examples/react-firebase/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
               sed 's/.*initializeApp(//g' | \
               sed 's/);//g' | \
               jq -r 'to_entries[] | [.key, (.value | tojson)] | join("::")' | \
-              sed 's/:"/:/g; s/^/echo \"REACT_APP_FB_/g' \
+              sed 's/::"/=/g; s/^/echo \"REACT_APP_FB_/g' \
           )
 
           # Loop through each line of config and evaluate to export env vars

--- a/examples/react-firestore/.github/workflows/deploy.yml
+++ b/examples/react-firestore/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
               sed 's/.*initializeApp(//g' | \
               sed 's/);//g' | \
               jq -r 'to_entries[] | [.key, (.value | tojson)] | join("::")' | \
-              sed 's/:"/:/g; s/^/echo \"REACT_APP_FB_/g' \
+              sed 's/::"/=/g; s/^/echo \"REACT_APP_FB_/g' \
           )
 
           # Loop through each line of config and evaluate to export env vars

--- a/examples/redux-firestore/.github/workflows/deploy.yml
+++ b/examples/redux-firestore/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
               sed 's/.*initializeApp(//g' | \
               sed 's/);//g' | \
               jq -r 'to_entries[] | [.key, (.value | tojson)] | join("::")' | \
-              sed 's/:"/:/g; s/^/echo \"REACT_APP_FB_/g' \
+              sed 's/::"/=/g; s/^/echo \"REACT_APP_FB_/g' \
           )
 
           # Loop through each line of config and evaluate to export env vars

--- a/generators/app/templates/.github/workflows/deploy.yml
+++ b/generators/app/templates/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
               sed 's/.*initializeApp(//g' | \
               sed 's/);//g' | \
               jq -r 'to_entries[] | [.key, (.value | tojson)] | join("::")' | \
-              sed 's/:"/:/g; s/^/echo \"REACT_APP_FB_/g' \
+              sed 's/::"/=/g; s/^/echo \"REACT_APP_FB_/g' \
           )
 
           # Loop through each line of config and evaluate to export env vars


### PR DESCRIPTION
### Description
The GitHub deploy action was failing because of the way the environment variables were attempting to be set during the `Set App Environment Settings` step. It was throwing this error:

`Invalid environment variable format 'REACT_APP_FB_projectId::my-firebase-app-name'`

This diff changes it to use `=` instead of `::` which seems to make GitHub happier.
